### PR TITLE
glue-qt 0.4.2 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,32 +1,32 @@
 {% set name = "glue-qt" %}
-{% set version = "0.3.3" %}
+{% set version = "0.4.2" %}
 
 package:
-  name: {{ name|lower }}
+  name: {{ name }}
   version: {{ version }}
 
 source:
   url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name | replace('-', '_') }}-{{ version }}.tar.gz
-  sha256: d3e8aa2e1f4092dfe8158523a4c9508f0759a400e8cca8a711669361ce23e883
+  sha256: a50a2641c0cfc23081e1e76e0267c73fa6ba2eccc6151c9143bc5e603f4c5423
 
 build:
   number: 0
-  # No dependencies for py39
-  skip: true  # [py<310]
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
   osx_is_app: true  # [osx]
   entry_points:
     - glue = glue_qt.main:main
+  skip: true  # [py<38]
 
 requirements:
   host:
     - pip
     - python
-    - setuptools
+    - wheel
+    - setuptools >=61.2
     - setuptools_scm
   run:
     - python
-    - glue-core >=1.15.0
+    - glue-core >=1.23.0
     - numpy >=1.17
     - matplotlib-base >=3.2
     - scipy >=1.1
@@ -34,12 +34,10 @@ requirements:
     - astropy >=4.0
     - setuptools >=30.3.0
     - qtpy >=1.9
-    - ipython >=4.0
+    - ipython >=4.0,<9.0
     - ipykernel >=4.0,!=5.0.0,!=5.1.0
     - qtconsole >=4.3,!=5.4.2
     - pvextractor >=0.2
-    - importlib-resources >=1.3  # [py<39]
-    - importlib-metadata >=3.6  # [py<310]
   run_constrained:
     - pyqt >=5.14,<6.0.0a0
 
@@ -53,7 +51,7 @@ test:
     - glue_qt
     - glue_qt.app
   requires:
-    - pip >=18.0
+    - pip
     - pytest
     - pyqt
     - setuptools >=30.3.0
@@ -80,3 +78,5 @@ about:
 extra:
   recipe-maintainers:
     - astrofrog
+  skip-lints:
+    - python_build_tool_in_run

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -15,7 +15,8 @@ build:
   osx_is_app: true  # [osx]
   entry_points:
     - glue = glue_qt.main:main
-  skip: true  # [py<38]
+  # Ipython 9.6.0+ start supporting python 3.14, skip 314.
+  skip: true  # [py<38 or py>313]
 
 requirements:
   host:


### PR DESCRIPTION
glue-qt 0.4.2 

**Destination channel:** Defaults

### Links

- [PKG-15718]
- dev_url:        https://github.com/glue-viz/glue-qt/tree/v0.4.2
- conda_forge:    https://github.com/conda-forge/glue-qt-feedstock
- pypi:           https://pypi.org/project/glue-qt/0.4.2
- pypi inspector: https://inspector.pypi.io/project/glue-qt/0.4.2

### Explanation of changes:

- new version number


[PKG-15718]: https://anaconda.atlassian.net/browse/PKG-15718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ